### PR TITLE
Update commands list in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ Available commands:
   split. Useful if you prefer a popup most of the time but want to temporarily
   swap for a particular task.
 
-* `ExecutorToggleDetail`: toggle the visibility of the details window.
+* `ExecutorShowPresets`: shows the preset commands set in config.
+  
+* `ExecutorShowHistory`: shows the previous commands run in the session.
 
 * `ExecutorReset`: will clear the output from the statusline and clear the
   stored command. Useful if your last run was a while ago, and the status


### PR DESCRIPTION
(Thanks for this nice plugin. My TDD flow has gotten slightly more efficient thanks to this :)

This PR includes the following changes in README:

1. The `ExecutorToggleDetail` command was mentioned twice. I removed the duplicate line.
2. The commands `ExecutorShowPresets` and `ExecutorShowHistory` weren't mentioned. I can see they were described in detail in the subsequent sections, but I included them here as well to keep the list comprehensive.