### PR TITLE
No-op if toggling detail before any tests have ben run

### DIFF
--- a/lua/executor/executor.lua
+++ b/lua/executor/executor.lua
@@ -385,6 +385,11 @@ M._show_split = function()
 end
 
 M.toggle_detail = function()
+  -- Don't attempt to show detail if no tests have been run.
+  if M._state.last_stdout == nil then
+    Output.write_data(nil, nil, nil, nil)
+    return
+  end
   if M._state.showing_detail == true then
     -- Need to ensure that we definitely are still showing the detail
     -- If the user has `:q` on the detail view, we might have the flag set to `true` but it actually have gone.

--- a/lua/executor/output.lua
+++ b/lua/executor/output.lua
@@ -70,6 +70,10 @@ M.process_lines = function(cmd, filter_function, input_lines)
 end
 
 M.write_data = function(cmd, bufnr, filter_function, input_lines)
+  if input_lines == nil then
+    print("Executor.nvim: No test run to show.")
+    return
+  end
   local trimmed_lines = filter_function(cmd, M._clean_lines(input_lines))
   local channel_id = vim.api.nvim_open_term(bufnr, {})
   vim.api.nvim_chan_send(channel_id, table.concat(trimmed_lines, "\n"))


### PR DESCRIPTION
Fixes #3 

> Load up NeoVim
> Call toggle/show details.
> This will error. It should likely just no-op and show a message like "no test run to show!".

Add a nil check to both `M.toggle_detail()` and `M.write_data()` to handle avoid erroring when toggling detail before any tests have been run.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR